### PR TITLE
Use different library names on Windows

### DIFF
--- a/lib/GTK/GDK.pm6
+++ b/lib/GTK/GDK.pm6
@@ -1,3 +1,14 @@
+my Str $gtklib;
+my Str $gdklib;
+BEGIN {
+    if $*VM.config<dll> ~~ /dll/ {
+        $gtklib = 'libgtk-3-0';
+        $gdklib = 'libgdk-3-0';
+    } else {
+        $gtklib = 'libgtk-3';
+        $gdklib = 'libgdk-3';
+    }
+}
 use NativeCall;
 
 class GdkWindow is repr('CPointer') { }
@@ -31,18 +42,18 @@ constant carrayuint16 := CArray[uint16];
 
 sub gtk_widget_get_window(OpaquePointer $window)
     returns GdkWindow
-    is native('libgtk-3')
+    is native($gtklib)
     is export
     {*}
 
 sub gdk_window_get_events(GdkWindow $window)
     returns int
-    is native('libgdk-3')
+    is native($gdklib)
     is export
     {*}
 
 sub gdk_window_set_events(GdkWindow $window, int $eventmask)
-    is native('libgdk-3')
+    is native($gdklib)
     is export
     {*}
 
@@ -51,11 +62,11 @@ sub gdk_window_set_events(GdkWindow $window, int $eventmask)
 class GdkEvent is repr('CPointer') { ... }
 
 sub gdk_event_get_keycode(GdkEvent $event, carrayuint16 $keycode)
-    is native('libgdk-3')
+    is native($gdklib)
     {*}
 
 sub gdk_event_get_keyval(GdkEvent $event, carrayuint16 $keycode)
-    is native('libgdk-3')
+    is native($gdklib)
     {*}
 
 class GdkEvent is repr('CPointer') {

--- a/lib/GTK/Simple.pm6
+++ b/lib/GTK/Simple.pm6
@@ -1,3 +1,17 @@
+my Str $gtklib;
+my Str $gobjectlib;
+my Str $gliblib;
+BEGIN {
+    if $*VM.config<dll> ~~ /dll/ {
+        $gtklib = 'libgtk-3-0';
+        $gobjectlib = 'libgobject-2.0-0';
+        $gliblib = 'libglib-2.0-0';
+    } else {
+        $gtklib = 'libgtk-3.so';
+        $gobjectlib = 'libgobject-2.0';
+        $gliblib = 'libglib-2.0';
+    }
+}
 use NativeCall;
 
 use GTK::GDK;
@@ -18,54 +32,54 @@ sub gtk_simple_use_cairo() is export {
 # gtk_widget_... {{{
 
 sub gtk_widget_show(GtkWidget $widgetw)
-    is native('libgtk-3.so')
+    is native($gtklib)
     {*}
 
 sub gtk_widget_destroy(GtkWidget $widget)
-    is native('libgtk-3.so')
+    is native($gtklib)
     {*}
 
 sub gtk_widget_set_sensitive(GtkWidget $widget, int $sensitive)
-    is native('libgtk-3.so')
+    is native($gtklib)
     {*}
 
 sub gtk_widget_get_sensitive(GtkWidget $widget)
     returns int
-    is native('libgtk-3.so')
+    is native($gtklib)
     {*}
 
 sub gtk_widget_set_size_request(GtkWidget $widget, int $w, int $h)
-    is native('libgtk-3.so')
+    is native($gtklib)
     {*}
 
 sub gtk_widget_get_allocated_height(GtkWidget $widget)
     returns int
-    is native('libgtk-3.so')
+    is native($gtklib)
     {*}
 
 sub gtk_widget_get_allocated_width(GtkWidget $widget)
     returns int
-    is native('libgtk-3.so')
+    is native($gtklib)
     {*}
 
 sub gtk_widget_queue_draw(GtkWidget $widget)
-    is native('libgtk-3.so')
+    is native($gtklib)
     {*}
 
 # gtk_widget_ ... }}}
 
 # gtk_container_... {{{
 sub gtk_container_add(GtkWidget $container, GtkWidget $widgen)
-    is native('libgtk-3.so')
+    is native($gtklib)
     {*}
 
 sub gtk_container_get_border_width(GtkWidget $container)
     returns int
-    is native('libgtk-3.so')
+    is native($gtklib)
     {*}
 
 sub gtk_container_set_border_width(GtkWidget $container, int $border_width)
-    is native('libgtk-3.so')
+    is native($gtklib)
     {*}
 
 # gtk_container_... }}}
@@ -76,12 +90,12 @@ sub g_signal_connect_wd(GtkWidget $widget, Str $signal,
     &Handler (GtkWidget $h_widget, OpaquePointer $h_data),
     OpaquePointer $data, int32 $connect_flags)
     returns int
-    is native('libgobject-2.0')
+    is native($gobjectlib)
     is symbol('g_signal_connect_object')
     { * }
 
 sub g_signal_handler_disconnect(GtkWidget $widget, int $handler_id)
-    is native('libgobject-2.0')
+    is native($gobjectlib)
     { * }
 
 # g_signal... }}}
@@ -89,12 +103,12 @@ sub g_signal_handler_disconnect(GtkWidget $widget, int $handler_id)
 sub g_idle_add(
         &Handler(OpaquePointer $h_data),
         OpaquePointer $data)
-    is native('libgtk-3.so')
+    is native($gliblib)
     returns int32
     {*}
 
 sub g_timeout_add(int32 $interval, &Handler(OpaquePointer $h_data, --> int), OpaquePointer $data)
-    is native('libgtk-3.so')
+    is native($gtklib)
     returns int32
     {*}
 
@@ -233,12 +247,12 @@ class GTK::Simple::Scheduler does Scheduler {
 class GTK::Simple::Window does GTK::Simple::Widget
                        does GTK::Simple::Container {
     sub gtk_window_new(int32 $window_type)
-        is native('libgtk-3.so')
+        is native($gtklib)
         returns GtkWidget
         {*}
 
     sub gtk_window_set_title(GtkWidget $w, Str $title)
-        is native('libgtk-3.so')
+        is native($gtklib)
         returns GtkWidget
         {*}
 
@@ -270,20 +284,20 @@ class GTK::Simple::Window does GTK::Simple::Widget
 class GTK::Simple::App does GTK::Simple::Widget
                        does GTK::Simple::Container {
     sub gtk_init(CArray[int32] $argc, CArray[CArray[Str]] $argv)
-        is native('libgtk-3.so')
+        is native($gtklib)
         {*}
 
     sub gtk_window_new(int32 $window_type)
-        is native('libgtk-3.so')
+        is native($gtklib)
         returns GtkWidget
         {*}
 
     sub gtk_main()
-        is native('libgtk-3.so')
+        is native($gtklib)
         {*}
 
     sub gtk_main_quit()
-        is native('libgtk-3.so')
+        is native($gtklib)
         {*}
 
     submethod BUILD(:$title = 'Application', Bool :$exit_on_close = True) {
@@ -350,7 +364,7 @@ class GTK::Simple::App does GTK::Simple::Widget
 
 role GTK::Simple::Box {
     sub gtk_box_pack_start(GtkWidget, GtkWidget, int32, int32, int32)
-        is native('libgtk-3.so')
+        is native($gtklib)
         {*}
 
     multi method new(*@packees) {
@@ -367,7 +381,7 @@ role GTK::Simple::Box {
 
 class GTK::Simple::HBox does GTK::Simple::Widget does GTK::Simple::Box {
     sub gtk_hbox_new(int32, int32)
-        is native('libgtk-3.so')
+        is native($gtklib)
         returns GtkWidget
         {*}
 
@@ -378,7 +392,7 @@ class GTK::Simple::HBox does GTK::Simple::Widget does GTK::Simple::Box {
 
 class GTK::Simple::VBox does GTK::Simple::Widget does GTK::Simple::Box {
     sub gtk_vbox_new(int32, int32)
-        is native('libgtk-3.so')
+        is native($gtklib)
         returns GtkWidget
         {*}
 
@@ -389,12 +403,12 @@ class GTK::Simple::VBox does GTK::Simple::Widget does GTK::Simple::Box {
 
 class GTK::Simple::Grid does GTK::Simple::Widget {
     sub gtk_grid_new()
-        is native('libgtk-3.so')
+        is native($gtklib)
         returns GtkWidget
         {*}
 
     sub gtk_grid_attach(GtkWidget $grid, GtkWidget $child, int $x, int $y, int $w, int $h)
-        is native('libgtk-3.so')
+        is native($gtklib)
         {*}
 
     method new(*@pieces) {
@@ -414,17 +428,17 @@ class GTK::Simple::Grid does GTK::Simple::Widget {
 
 class GTK::Simple::Label does GTK::Simple::Widget {
     sub gtk_label_new(Str $text)
-        is native('libgtk-3.so')
+        is native($gtklib)
         returns GtkWidget
         {*}
 
     sub gtk_label_get_text(GtkWidget $label)
-        is native('libgtk-3.so')
+        is native($gtklib)
         returns Str
         {*}
 
     sub gtk_label_set_text(GtkWidget $label, Str $text)
-        is native('libgtk-3.so')
+        is native($gtklib)
         {*}
 
     submethod BUILD(:$text = '') {
@@ -442,17 +456,17 @@ class GTK::Simple::Label does GTK::Simple::Widget {
 
 class GTK::Simple::Entry does GTK::Simple::Widget {
     sub gtk_entry_new()
-        is native('libgtk-3.so')
+        is native($gtklib)
         returns GtkWidget
         {*}
 
     sub gtk_entry_get_text(GtkWidget $entry)
-        is native('libgtk-3.so')
+        is native($gtklib)
         returns Str
         {*}
 
     sub gtk_entry_set_text(GtkWidget $entry, Str $text)
-        is native('libgtk-3.so')
+        is native($gtklib)
         {*}
 
     submethod BUILD() {
@@ -484,31 +498,31 @@ class GTK::Simple::Entry does GTK::Simple::Widget {
 
 class GTK::Simple::TextView does GTK::Simple::Widget {
     sub gtk_text_view_new()
-        is native('libgtk-3.so')
+        is native($gtklib)
         returns GtkWidget
         {*}
 
     our sub gtk_text_view_get_buffer(GtkWidget $view)
-        is native('libgtk-3.so')
+        is native($gtklib)
         returns OpaquePointer
         {*}
 
     our sub gtk_text_buffer_get_text(OpaquePointer $buffer, CArray[int] $start,
             CArray[int] $end, int32 $show_hidden)
-        is native('libgtk-3.so')
+        is native($gtklib)
         returns Str
         {*}
 
     our sub gtk_text_buffer_get_start_iter(OpaquePointer $buffer, CArray[int] $i)
-        is native('libgtk-3.so')
+        is native($gtklib)
         {*}
 
     our sub gtk_text_buffer_get_end_iter(OpaquePointer $buffer, CArray[int] $i)
-        is native('libgtk-3.so')
+        is native($gtklib)
         {*}
 
     our sub gtk_text_buffer_set_text(OpaquePointer $buffer, Str $text, int32 $len)
-        is native('libgtk-3.so')
+        is native($gtklib)
         {*}
 
     has $!buffer;
@@ -562,7 +576,7 @@ class GTK::Simple::TextView does GTK::Simple::Widget {
 
 class GTK::Simple::Button does GTK::Simple::Widget {
     sub gtk_button_new_with_label(Str $label)
-        is native('libgtk-3.so')
+        is native($gtklib)
         returns GtkWidget
         {*}
 
@@ -588,17 +602,17 @@ class GTK::Simple::Button does GTK::Simple::Widget {
 
 class GTK::Simple::ToggleButton does GTK::Simple::Widget {
     sub gtk_toggle_button_new_with_label(Str $label)
-        is native('libgtk-3.so')
+        is native($gtklib)
         returns GtkWidget
         {*}
 
     sub gtk_toggle_button_get_active(GtkWidget $w)
-        is native('libgtk-3.so')
+        is native($gtklib)
         returns int
         {*}
 
     sub gtk_toggle_button_set_active(GtkWidget $w, int $active)
-        is native('libgtk-3.so')
+        is native($gtklib)
         returns int
         {*}
 
@@ -632,7 +646,7 @@ class GTK::Simple::ToggleButton does GTK::Simple::Widget {
 
 class GTK::Simple::CheckButton is GTK::Simple::ToggleButton {
     sub gtk_check_button_new_with_label(Str $label)
-        is native('libgtk-3.so')
+        is native($gtklib)
         returns GtkWidget
         {*}
 
@@ -643,17 +657,17 @@ class GTK::Simple::CheckButton is GTK::Simple::ToggleButton {
 
 class GTK::Simple::Switch is GTK::Simple::ToggleButton {
     sub gtk_switch_new()
-        is native('libgtk-3.so')
+        is native($gtklib)
         returns GtkWidget
         {*}
 
     sub gtk_switch_get_active(GtkWidget $w)
         returns int
-        is native('libgtk-3.so')
+        is native($gtklib)
         {*}
 
     sub gtk_switch_set_active(GtkWidget $w, int $a)
-        is native('libgtk-3.so')
+        is native($gtklib)
         {*}
 
     method creation_sub {
@@ -669,7 +683,7 @@ class GTK::Simple::Switch is GTK::Simple::ToggleButton {
 
 class GTK::Simple::DrawingArea does GTK::Simple::Widget {
     sub gtk_drawing_area_new()
-        is native('libgtk-3.so')
+        is native($gtklib)
         returns GtkWidget
         {*}
 

--- a/lib/GTK/Simple.pm6
+++ b/lib/GTK/Simple.pm6
@@ -7,7 +7,7 @@ BEGIN {
         $gobjectlib = 'libgobject-2.0-0';
         $gliblib = 'libglib-2.0-0';
     } else {
-        $gtklib = 'libgtk-3.so';
+        $gtklib = 'libgtk-3';
         $gobjectlib = 'libgobject-2.0';
         $gliblib = 'libglib-2.0';
     }


### PR DESCRIPTION
When we're loading .dll's instead of .so files, use the library filenames
that come in the gtk3 windows binary download.

Also note the definition of g_idle_add - the library was changed from
libgtk to libglib, as it was throwing a 'symbol not found' error.
